### PR TITLE
Introduce `whitelisted_authors` and `whitelisted_authors_regex` options

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,9 @@ gem 'nokogiri', '~> 1.8'
 
 group :development do
   gem 'mina'
+end
+
+group :development, :test do
   gem 'pry'
+  gem 'rspec'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ GEM
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     daemons (1.2.4)
+    diff-lcs (1.3)
     easy_conf (0.2.0)
     eventmachine (1.2.5)
     faraday (0.13.1)
@@ -33,6 +34,19 @@ GEM
     rack-protection (1.5.3)
       rack
     rake (12.0.0)
+    rspec (3.6.0)
+      rspec-core (~> 3.6.0)
+      rspec-expectations (~> 3.6.0)
+      rspec-mocks (~> 3.6.0)
+    rspec-core (3.6.0)
+      rspec-support (~> 3.6.0)
+    rspec-expectations (3.6.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.6.0)
+    rspec-mocks (3.6.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.6.0)
+    rspec-support (3.6.0)
     sentry-raven (2.6.3)
       faraday (>= 0.7.6, < 1.0)
     sinatra (1.4.8)
@@ -61,6 +75,7 @@ DEPENDENCIES
   mina
   nokogiri (~> 1.8)
   pry
+  rspec
   sentry-raven
   sinatra
   sinatra-json

--- a/app/factories/application_factory.rb
+++ b/app/factories/application_factory.rb
@@ -10,20 +10,25 @@ class ApplicationFactory
     end
 
     private
-      # This is not good
       def create_applications
-        applications_persisted = Application.all
-
         $app_config.applications.map do |app_name, configs|
-          application = applications_persisted.select { |app| app_name == app.name }.first
-
-          if application
-            application.instance_variable_set(:@configuration, Configuration.new(application, configs))
-            application
-          else
-            Application.new(app_name, configs)
+          (persisted_application(app_name) || Application.new(app_name)).tap do |application|
+            application.configuration = create_configuration(configs)
+            application.repository    = create_repository(application, configs)
           end
         end
+      end
+
+      def create_configuration(configs)
+        Configuration.new(configs)
+      end
+
+      def create_repository(application, configs)
+        Repository.new(application, configs['repository'], configs['branch'])
+      end
+
+      def persisted_application(app_name)
+        Application.all.select { |app| app_name == app.name }.first
       end
 
   end

--- a/app/factories/author_factory.rb
+++ b/app/factories/author_factory.rb
@@ -1,0 +1,19 @@
+class AuthorFactory
+  AUTHOR_REGEX = /(.+)\s<(.+)>/i
+
+  class << self
+    def create(commit)
+      name, email = parse_commit_author(commit.git_author)
+
+      Author.new(commit, name, email)
+    end
+
+    private
+      def parse_commit_author(commit_author)
+        match_data = commit_author.match(AUTHOR_REGEX).to_a
+        match_data[1..2]
+      end
+
+  end
+
+end

--- a/app/factories/commit_factory.rb
+++ b/app/factories/commit_factory.rb
@@ -1,0 +1,14 @@
+class CommitFactory
+  COMMIT_REGEX = /commit\s(.+)$\n^author:\s(.+)$\n^date:\s(.+)$\n((?:\s\n*.+\n*)+)\s?(?=commit)?/i
+
+  class << self
+    def create_list(release)
+      release.git_changes.scan(COMMIT_REGEX).map do |match|
+        Commit.new(release, match[0], match[1], match[2], match[3]).tap do |commit|
+          commit.author = AuthorFactory.create(commit)
+        end
+      end
+    end
+  end
+
+end

--- a/app/factories/release_factory.rb
+++ b/app/factories/release_factory.rb
@@ -1,0 +1,13 @@
+class ReleaseFactory
+
+  class << self
+    def create(application, version)
+      release = Release.new(application, version)
+      return if release.is_empty?
+
+      release.note.save
+      release
+    end
+  end
+
+end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -1,10 +1,10 @@
 class Application < AbstractModel
-  attr_reader :name, :configuration, :repository, :releases
+  attr_reader :name
+  attr_accessor :configuration, :repository
 
-  def initialize(app_name, configs)
+  def initialize(app_name)
     @name = app_name
 
-    create_children(configs)
     init_file_system!
   end
 
@@ -19,22 +19,16 @@ class Application < AbstractModel
   end
 
   def create_release_candidate
-    release = Release.new(self, next_release_version)
-    return if release.is_empty?
-
-    release.note.save
-    releases << release
+    release = ReleaseFactory.create(self, next_release_version)
+    releases << release if release
   end
 
   def next_release_version
     releases.last&.version.to_i + 1
   end
 
-  private
-    def create_children(configs)
-      @configuration = Configuration.new(self, configs)
-      @releases      = []
-      @repository    = Repository.new(self, configs['repository'], configs['branch'])
-    end
+  def releases
+    @releases ||= []
+  end
 
 end

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -1,0 +1,35 @@
+class Author
+  attr_reader :commit, :name, :email
+
+  def initialize(commit, name, email)
+    @commit = commit
+    @name   = name
+    @email  = email
+  end
+
+  # lol
+  def is_notifiable?
+    (whitelisted_regex &&
+      (email =~ whitelisted_regex || whitelisted_list.to_a.include?(email))) ||
+        (!whitelisted_regex &&
+          (!whitelisted_list || whitelisted_list.include?(email)))
+  end
+
+  def ==(other)
+    other.respond_to?(:email) && email == other.email
+  end
+
+  private
+    def whitelisted_regex
+      Regexp.new(application_config.whitelisted_authors_regex) if application_config.whitelisted_authors_regex
+    end
+
+    def whitelisted_list
+      application_config.whitelisted_authors
+    end
+
+    def application_config
+      @application_config ||= commit.release.application.configuration
+    end
+
+end

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -1,15 +1,16 @@
 class Commit < AbstractModel
-  COMMIT_REGEX = /commit\s(.+)$\n^author:\s(.+)$\n^date:\s(.+)$\n((?:\s\n*.+\n*)+)\s?(?=commit)?/i
   DATE_PATTERN = '%Y-%m-%d %H:%M'
   HOTFIX_REGEX = /<<hotfix>>/i
 
-  attr_reader :hash, :author, :date, :message
+  attr_reader :release, :hash, :git_author, :date, :message
+  attr_accessor :author
 
-  def initialize(hash, author, date, message)
-    @hash    = hash
-    @author  = author
-    @date    = date
-    @message = message
+  def initialize(release, hash, git_author, date, message)
+    @release    = release
+    @hash       = hash
+    @git_author = git_author
+    @date       = date
+    @message    = message
   end
 
   def pretty_date
@@ -18,12 +19,6 @@ class Commit < AbstractModel
 
   def is_hotfix?
     message =~ HOTFIX_REGEX
-  end
-
-  def self.list_from_git_log(git_log)
-    git_log.scan(COMMIT_REGEX).map do |match|
-      new(match[0], match[1], match[2], match[3])
-    end
   end
 
 end

--- a/app/models/configuration.rb
+++ b/app/models/configuration.rb
@@ -1,14 +1,20 @@
 class Configuration < AbstractModel
+  ATTRIBUTES = [
+    :period,
+    :stakeholders,
+    :whitelisted_authors,
+    :whitelisted_authors_regex,
+    :postpone_for,
+    :deploy_after,
+    :deploy_before
+  ]
 
-  attr_reader :application, :period, :stakeholders, :postpone_for, :deploy_after, :deploy_before
+  attr_reader *ATTRIBUTES
 
-  def initialize(application, configs)
-    @application   = application
-    @period        = configs['period']
-    @stakeholders  = configs['stakeholders']
-    @postpone_for  = configs['postpone_for']
-    @deploy_after  = configs['deploy_after']
-    @deploy_before = configs['deploy_before']
+  def initialize(configs)
+    ATTRIBUTES.each do |attribute|
+      instance_variable_set("@#{attribute}", configs[attribute.to_s])
+    end
   end
 
 end

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -20,11 +20,15 @@ class Release < AbstractModel
   end
 
   def commits
-    @commits ||= Commit.list_from_git_log(git_changes)
+    @commits ||= CommitFactory.create_list(self)
+  end
+
+  def authors
+    commits.map(&:author)
   end
 
   def note
-    @release ||= Note.new(self)
+    @note ||= Note.new(self)
   end
 
   def path
@@ -39,9 +43,8 @@ class Release < AbstractModel
     commits.blank?
   end
 
-  private
-    def git_changes
-      application.repository.changes_on(serialization_name)
-    end
+  def git_changes
+    application.repository.changes_on(serialization_name)
+  end
 
 end

--- a/app/workers/scm.rb
+++ b/app/workers/scm.rb
@@ -18,7 +18,7 @@ class SCM
     while(true) do
       application.init_file_system!
       application.create_release_candidate
-      sleep(application.period)
+      sleep(application.configuration.period)
     end
   end
 

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -5,6 +5,10 @@ applications:
     period: 3600
     stakeholders:
       - john.doe@foo.bar
+    whitelisted_authors:
+      - john.doe@foo.bar
+    whitelisted_authors_regex:
+      .+@foo.bar
     postpone_for: 3600
     deploy_after: 25200
     deploy_before: 61200

--- a/spec/fixtures/application.yml
+++ b/spec/fixtures/application.yml
@@ -1,0 +1,3 @@
+application:
+  name: Foo
+  configuration@: configuration

--- a/spec/fixtures/author.yml
+++ b/spec/fixtures/author.yml
@@ -1,0 +1,4 @@
+author:
+  commit@: commit
+  name: John Doe
+  email: foo@bar

--- a/spec/fixtures/commit.yml
+++ b/spec/fixtures/commit.yml
@@ -1,0 +1,6 @@
+commit:
+  release@: release
+  hash: foo
+  git_author: John Doe
+  date: '29.10.1923'
+  message: WhAt A mEaNiNgFuL mEsSaGe

--- a/spec/fixtures/configuration.yml
+++ b/spec/fixtures/configuration.yml
@@ -1,0 +1,11 @@
+configuration:
+  period: 3600
+  stakeholders:
+    - john.doe@foo.bar
+  whitelisted_authors:
+    - john.doe@foo.bar
+  whitelisted_authors_regex:
+    .+@foo.bar
+  postpone_for: 3600
+  deploy_after: 25200
+  deploy_before: 61200

--- a/spec/fixtures/release.yml
+++ b/spec/fixtures/release.yml
@@ -1,0 +1,3 @@
+release:
+  application@: application
+  version: 1

--- a/spec/models/author_spec.rb
+++ b/spec/models/author_spec.rb
@@ -1,0 +1,103 @@
+require 'spec_helper'
+
+describe Author do
+
+  let(:empty_config)   { fixture :configuration, whitelisted_authors_regex: nil, whitelisted_authors: nil }
+  let(:regex_config_1) { fixture :configuration, whitelisted_authors_regex: 'foo@.+', whitelisted_authors: nil }
+  let(:regex_config_2) { fixture :configuration, whitelisted_authors_regex: 'zoo@.+', whitelisted_authors: nil }
+
+  subject { fixture :author }
+
+  describe '#==' do
+    context 'when the argument does not respond to #email' do
+      it 'returns false' do
+        expect(subject == Hash.new).to be_falsy
+      end
+    end
+
+    context 'when the argument respond to #email' do
+      context 'when the emails of authors are same' do
+        let(:author) { Author.new(nil, 'Alice', 'foo@bar') }
+
+        it 'returns true' do
+          expect(subject == author).to be_truthy
+        end
+      end
+
+      context 'when the emails of authors are not same' do
+        let(:author) { Author.new(nil, 'John Doe', 'foo@bar.zoo') }
+
+        it 'returns false' do
+          expect(subject == author).to be_falsy
+        end
+      end
+    end
+  end
+
+  describe '#is_notifiable?' do
+    context 'when neither regex nor list configuration provided' do
+      before { allow(subject).to receive(:application_config).and_return(empty_config) }
+
+      it 'returns true' do
+        expect(subject.is_notifiable?).to be_truthy
+      end
+    end
+
+    context 'when whitelisted_authors_regex configuration is provided' do
+      context 'when the email of author does not match with configuration' do
+        before { allow(subject).to receive(:application_config).and_return(regex_config_2) }
+
+        context 'when whitelisted_list configuration is not provided' do
+          it 'returns false' do
+            expect(subject.is_notifiable?).to be_falsy
+          end
+        end
+
+        context 'when whitelisted_list configuration is provided' do
+          context 'when the author email is whitelisted' do
+            before { allow(subject).to receive(:whitelisted_list).and_return([subject.email]) }
+
+            it 'returns false' do
+              expect(subject.is_notifiable?).to be_truthy
+            end
+
+            context 'when the author email is not whitelisted' do
+              before { allow(subject).to receive(:whitelisted_list).and_return([nil]) }
+
+              it 'returns false' do
+                expect(subject.is_notifiable?).to be_falsy
+              end
+            end
+          end
+        end
+      end
+
+      context 'when the email of author matches with configuration' do
+        before { allow(subject).to receive(:application_config).and_return(regex_config_1) }
+
+        it 'returns true' do
+          expect(subject.is_notifiable?).to be_truthy
+        end
+      end
+    end
+
+    context 'when whitelisted_authors configuration is provided' do
+      context 'when the author email is whitelisted' do
+        before { allow(subject).to receive(:whitelisted_list).and_return([subject.email]) }
+
+        it 'returns false' do
+          expect(subject.is_notifiable?).to be_truthy
+        end
+
+        context 'when the author email is not whitelisted' do
+          before { allow(subject).to receive(:whitelisted_list).and_return([nil]) }
+
+          it 'returns false' do
+            expect(subject.is_notifiable?).to be_falsy
+          end
+        end
+      end
+    end
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,24 @@
+require_relative '../boot.rb'
+Dir["spec/support/*.rb"].each {|file| require File.expand_path(file) }
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+
+  config.order = :random
+
+  config.filter_run_when_matching :focus
+
+  config.warnings = true
+
+  Kernel.srand config.seed
+
+  config.include Fixtures
+end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1,0 +1,47 @@
+module Fixtures
+  # fixture :application
+  # fixture :application, :rails
+  # fixture :application, name: :rails
+  # fixture :application, :rails, name: :rails
+  def fixture(*args)
+    model, fixture, extra = parse_given_args(args)
+    model_data     = load_model_file(model)
+    fixture_data   = model_data[fixture.to_s]
+
+    instantiate_model(model, fixture_data, extra)
+  end
+
+  private
+    def load_model_file(fixture_name)
+      YAML.load_file("spec/fixtures/#{fixture_name}.yml")
+    rescue Errno::ENOENT
+      raise "No fixture file found for #{fixture_name}"
+    end
+
+    def parse_given_args(args)
+      name, opts = (args[1].respond_to?(:keys) ? args[0..1] : args[1..2])
+      [args[0], name || args[0], opts || {}]
+    end
+
+    def instantiate_model(model, data, **extra)
+      model.to_s.classify.constantize.allocate.tap do |object|
+        data.each do |variable_name, value|
+          value_to_set = extra.fetch(variable_name.to_sym, value)
+          set_data_on(object, variable_name, value_to_set)
+        end
+      end
+    end
+
+    # If the variable name ends with @ this means
+    # the variable should be resolved as fixture
+    def set_data_on(object, variable_name, value)
+      if variable_name.end_with?('@')
+        relation_name = variable_name[0...-1]
+
+        object.instance_variable_set("@#{relation_name}", fixture(value))
+      else
+        object.instance_variable_set("@#{variable_name}", value)
+      end
+    end
+
+end


### PR DESCRIPTION
If the `whitelisted_authors_regex` is provided the author email will be
checked with this value. If it matches author will be notifiable if not
and `whitelisted_authors` is provided, the email of the author will be
tested with the given list. If the email of the author is in this list
author will be notifiable, otherwise marked as not notifiable.

Long story short; `whitelisted_authors` always override the regex option
if both of them are provided. Otherwise the logic is quite simple check,
as their name suggest.

Closes #3 